### PR TITLE
change the definition of object_msgs

### DIFF
--- a/msg/Object.msg
+++ b/msg/Object.msg
@@ -13,6 +13,5 @@
 # limitations under the License.
 
 # This message define the property of detected object
-uint32 label        # label of object defined in dataset classes
-string object_name  # object's name
+string object_name  # object name
 float32 probability # probability of detected object

--- a/msg/ObjectInBox.msg
+++ b/msg/ObjectInBox.msg
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 # This message can represent a detected object and its region of interest
-Object object                     # object detected
+Object object                     # detected object
 sensor_msgs/RegionOfInterest roi  # region of interest

--- a/msg/Objects.msg
+++ b/msg/Objects.msg
@@ -13,5 +13,6 @@
 # limitations under the License.
 
 # This message can represent objects detected in a frame
-std_msgs/Header header  # timestamp in header is the time the sensor captured the raw data
-Object[] objects_vector # Object array
+std_msgs/Header header    # timestamp in header is the time the sensor captured the raw data
+Object[] objects_vector   # Object array
+float32 inference_time_ms # inference time of this frame. the unit is millisecond.

--- a/msg/ObjectsInBoxes.msg
+++ b/msg/ObjectsInBoxes.msg
@@ -15,3 +15,4 @@
 # This message can represent objects detected and their bounding-boxes in a frame
 std_msgs/Header header        # timestamp in header is the time the sensor captured the raw data
 ObjectInBox[] objects_vector  # ObjectInBox array
+float32 inference_time_ms     # inference time of this frame. the unit is millisecond.


### PR DESCRIPTION
1. remove the variant of label in Object.msg
2. add a variant of inference_time_ms in Objects.msg and ObjectsInBoxes.msg

Signed-off-by: Xiaojun Huang <xiaojun.huang@intel.com>
  