### PR TITLE
add a srv file to support  ros_openvino_toolkit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_message_files(DIRECTORY msg FILES
 add_service_files(DIRECTORY srv FILES
   ClassifyObject.srv
   DetectObject.srv
+  DetectObjectSrv.srv
 )
 
 generate_messages(DEPENDENCIES

--- a/srv/DetectObjectSrv.srv
+++ b/srv/DetectObjectSrv.srv
@@ -1,0 +1,17 @@
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+string image_path      # image path list for inference
+---
+ObjectsInBoxes[] objects  # bounding box list for each of inferred images


### PR DESCRIPTION
Hi all,
There is a inconsistent defination of DetectObject.srv between ROS2 and ROS. I hope that I can add a new srv file to have a same interface in ROS1 and ROS2 instead of modify it, since I guess other projects may rely on this message defination.

----------------------------------------------------

DetectObject.srv in ROS2 [ros2_object_msgs](https://github.com/intel/ros2_object_msgs/blob/master/srv/DetectObject.srv):

string image_path         

DetectObject in ROS1 [object_msgs](https://github.com/intel/object_msgs/blob/master/srv/DetectObject.srv):

string[] image_paths      # image path list for inference
